### PR TITLE
Add db interop apis

### DIFF
--- a/bigg_models/handlers/db_interop_handlers.py
+++ b/bigg_models/handlers/db_interop_handlers.py
@@ -1,0 +1,135 @@
+import tornado
+from tornado.web import RedirectHandler, RequestHandler, HTTPError
+from tornado.escape import json_decode
+
+from bigg_models.handlers import utils
+from bigg_models.queries import gene_queries, genome_queries
+
+from sqlalchemy import inspect
+
+class BaseInteropQueryHandler(tornado.web.RequestHandler):
+
+    def _parse_json(self):
+        try:
+            return tornado.escape.json_decode(self.request.body or b"{}")
+        except ValueError:
+            raise tornado.web.HTTPError(400, reason="Invalid JSON payload.")
+
+    def write_error(self, status_code: int, **kwargs):
+        exc_info = kwargs.get("exc_info")
+        if exc_info is not None:
+            err = exc_info[1]
+            self.write({"error": str(err)})
+        else:
+            self.write({"error": self._reason})
+
+
+class QueryByGeneHandler(BaseInteropQueryHandler):
+    async def post(self):
+        print("interop-query: query-by-gene")
+
+        data = self._parse_json()
+        gene_names = data.get("ids")
+        if not isinstance(gene_names, list):
+            raise tornado.web.HTTPError(400, reason="'ids' must be a list.")
+
+        gene_ids = [
+            row[0]
+            for gene in gene_names
+            for row in utils.safe_query(gene_queries.get_gene_ids_for_gene_name, gene)
+        ]
+
+        if not gene_ids:
+            self.finish({"results": []})
+            return
+
+        genes_info = utils.safe_query(gene_queries.get_genes, gene_ids)
+        gene_info_map = {g["id"]: g for g in genes_info}
+
+        regions = utils.safe_query(gene_queries.get_genome_region_for_gene_id, gene_ids)
+
+        results = []
+        for region in regions:
+            gid   = region["id"]
+            ginfo = gene_info_map.get(gid, {})
+
+            results.append({
+                "gene_id":      gid,
+                "name":         ginfo.get("name"),
+                "bigg_id":      ginfo.get("bigg_id"),
+                "locus_tag":    ginfo.get("locus_tag"),
+                "mapped_to_genbank": ginfo.get("mapped_to_genbank"),
+                "genome_region": {k: v for k, v in region.items()},
+            })
+
+        self.finish({"results": results})
+
+
+class QueryByStrainHandler(BaseInteropQueryHandler):
+    async def post(self):
+        print("interop-query: query-by-strain")
+
+        data = self._parse_json()
+        taxon_ids = data.get("ids")
+        if not isinstance(taxon_ids, list):
+            raise tornado.web.HTTPError(400, reason="'ids' must be a list.")
+
+        taxon_ids = {str(tid) for tid in taxon_ids}
+        if not taxon_ids:
+            self.finish({"results": []})
+            return
+
+        results = utils.safe_query(
+            genome_queries.get_genomes_with_chromosomes,
+            taxon_ids,
+        )
+
+        self.finish({"results": results})
+
+class QueryByPairHandler(BaseInteropQueryHandler):
+    async def post(self):
+        print("interop-query: query-by-pair")
+        data = self._parse_json()
+        pairs = data.get("pairs")
+        if not isinstance(pairs, list):
+            raise tornado.web.HTTPError(400, reason="'pairs' must be a list of objects.")
+
+        for i, pair in enumerate(pairs):
+            if not isinstance(pair, dict) or "gene" not in pair or "strain" not in pair:
+                raise tornado.web.HTTPError(
+                    400,
+                    reason=f"Each element in 'pairs' must be an object with 'gene' and 'strain' keys (error at index {i}).",
+                )
+
+        pair_results = []
+        for pair in pairs:
+            gene_name  = pair["gene"]
+            strain_id  = str(pair["strain"])
+
+            gene_ids = {
+                row[0]
+                for row in utils.safe_query(
+                    gene_queries.get_gene_ids_for_gene_name,
+                    gene_name,
+                )
+            }
+
+            if not gene_ids:
+                pair_results.append({"gene": gene_name, "strain": strain_id, "genomes": []})
+                continue
+
+            genomes = utils.safe_query(
+                genome_queries.get_genomes_with_chromosomes,
+                {strain_id},
+                gene_ids 
+            )
+
+            pair_results.append(
+                {
+                    "gene":   gene_name,
+                    "strain": strain_id,
+                    "genomes": genomes,
+                }
+            )
+
+        self.finish({"pairs": pair_results})

--- a/bigg_models/queries/gene_queries.py
+++ b/bigg_models/queries/gene_queries.py
@@ -9,11 +9,51 @@ from cobradb.models import (
     ModelGene,
     ModelReaction,
     Reaction,
+    GenomeRegion
 )
 
 from sqlalchemy import func
 
 
+def get_gene_ids_for_gene_name(name, session):
+    """Get the gene ids for a gene name."""
+    return (
+        session.query(Gene.id)
+        .filter(func.lower(Gene.name) == func.lower(name))
+        .all()
+    )
+
+def get_genes(gene_ids, session):
+    """Get the genes for a list of gene ids."""
+    rows = (
+        session.query(Gene.id, Gene.bigg_id, Gene.name, Gene.locus_tag, Gene.mapped_to_genbank)
+        .filter(Gene.id.in_(list(gene_ids)))
+        .all()
+    )
+
+    return [dict(r._mapping) for r in rows]
+
+def get_genome_region_for_gene_id(ids, session):
+    """Get the genome region for a gene id."""
+    rows = (
+        session.query(
+            GenomeRegion.id,
+            GenomeRegion.chromosome_id,
+            GenomeRegion.bigg_id,
+            GenomeRegion.leftpos,
+            GenomeRegion.rightpos,
+            GenomeRegion.strand,
+            GenomeRegion.type,
+            GenomeRegion.dna_sequence,
+            GenomeRegion.protein_sequence,
+        )
+        .filter(GenomeRegion.id.in_(list(ids)))
+        .all()
+    )
+
+    return [dict(r._mapping) for r in rows]
+
+    
 def get_model_genes_count(model_bigg_id, session):
     """Get the number of gene for the given model."""
     return (

--- a/bigg_models/queries/genome_queries.py
+++ b/bigg_models/queries/genome_queries.py
@@ -1,6 +1,7 @@
 from cobradb.util import ref_tuple_to_str, ref_str_to_tuple
-from cobradb.models import Genome, Chromosome, Model
+from cobradb.models import Genome, Chromosome, Model, GenomeRegion
 
+from sqlalchemy import inspect
 
 def get_genome_list(session):
     genome_db = session.query(Genome)
@@ -35,3 +36,68 @@ def get_genome_and_models(genome_ref_string, session):
         "models": [x.bigg_id for x in models_db],
         "chromosomes": [x.ncbi_accession for x in chromosomes_db],
     }
+
+def get_genomes_with_chromosomes(taxon_ids, gene_id_filter=None, session=None):
+    if not taxon_ids:
+        return []
+
+    genomes = (
+        session.query(Genome)
+        .filter(Genome.taxon_id.in_(list(taxon_ids)))
+        .all()
+    )
+    if not genomes:
+        return []
+
+    genome_ids = [g.id for g in genomes]
+
+    chromosomes = (
+        session.query(Chromosome)
+        .filter(Chromosome.genome_id.in_(genome_ids))
+        .all()
+    )
+    if not chromosomes:
+        chrom_map = {}
+    else:
+        chrom_ids = [c.id for c in chromosomes]
+
+        region_query = session.query(GenomeRegion).filter(
+            GenomeRegion.chromosome_id.in_(chrom_ids)
+        )
+        
+        if gene_id_filter is not None:
+            filt_ids = set(map(int, gene_id_filter))
+            if filt_ids:
+                region_query = region_query.filter(GenomeRegion.id.in_(filt_ids))
+            else:
+                region_query = region_query.filter(False)
+
+        regions = region_query.all()
+
+        region_map = {}
+        for r in regions:
+            region_dict = {
+                col.key: getattr(r, col.key)
+                for col in inspect(GenomeRegion).mapper.column_attrs
+            }
+            region_map.setdefault(r.chromosome_id, []).append(region_dict)
+
+        chrom_map = {}
+        for c in chromosomes:
+            chrom_dict = {
+                col.key: getattr(c, col.key)
+                for col in inspect(Chromosome).mapper.column_attrs
+            }
+            chrom_dict["genome_region"] = region_map.get(c.id, [])
+            chrom_map.setdefault(c.genome_id, []).append(chrom_dict)
+
+    results = []
+    for g in genomes:
+        genome_dict = {
+            col.key: getattr(g, col.key)
+            for col in inspect(Genome).mapper.column_attrs
+        }
+        genome_dict["chromosome"] = chrom_map.get(g.id, [])
+        results.append(genome_dict)
+
+    return results

--- a/bigg_models/routes.py
+++ b/bigg_models/routes.py
@@ -7,6 +7,7 @@ from bigg_models.handlers import (
     metabolite_handlers,
     model_handlers,
     search_handlers,
+    db_interop_handlers,
 )
 from os import path
 from tornado.web import RedirectHandler
@@ -161,6 +162,18 @@ def get_routes():
             r"/multiecoli/?$",
             RedirectHandler,
             {"url": "http://bigg1.ucsd.edu/multiecoli"},
+        ),
+        (
+            r"/interop-query/query-by-gene/?$", 
+            db_interop_handlers.QueryByGeneHandler
+        ),
+        (
+            r"/interop-query/query-by-strain/?$", 
+            db_interop_handlers.QueryByStrainHandler
+        ),
+        (  
+            r"/interop-query/query-by-pair/?$", 
+            db_interop_handlers.QueryByPairHandler
         ),
     ]
     return routes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
     networks:
       - biggr-net
     volumes:
-      - ${HOME}/Downloads/data/biggr-genbank/:/genbank
-      - ${HOME}/Downloads/data/biggr-metanetx/:/metanetx
-      - ${HOME}/Downloads/data/biggr-static/:/static
+      - /data/biggr-genbank/:/genbank
+      - /data/biggr-metanetx/:/metanetx
+      - /data/biggr-static/:/static
   biggr-web-dev:
     profiles:
       - dev
@@ -33,19 +33,19 @@ services:
     networks:
       - biggr-net
     volumes:
-      - ${HOME}/Downloads/data/biggr-genbank/:/genbank
-      - ${HOME}/Downloads/data/biggr-metanetx/:/metanetx
-      - ${HOME}/Downloads/data/biggr-static/:/static
+      - /data/biggr-genbank/:/genbank
+      - /data/biggr-metanetx/:/metanetx
+      - /data/biggr-static/:/static
       - ./:/server
   biggr-db:
     container_name: biggr-postgres
     image: postgres
     restart: always
     ports:
-      - "5433:5432"
+      - "5432:5432"
     volumes:
-      - ${HOME}/Downloads/data/biggr-postgres:/var/lib/postgresql/data
-      - ./db/load-extensions.sh:/docker-entrypoint-initdb.d/load-extensions.sh
+      - /data/biggr-postgres:/var/lib/postgresql/data
+      - /projects/biggr/biggr_models/db/load-extensions.sh:/docker-entrypoint-initdb.d/load-extensions.sh
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 1s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
     networks:
       - biggr-net
     volumes:
-      - /data/biggr-genbank/:/genbank
-      - /data/biggr-metanetx/:/metanetx
-      - /data/biggr-static/:/static
+      - ${HOME}/Downloads/data/biggr-genbank/:/genbank
+      - ${HOME}/Downloads/data/biggr-metanetx/:/metanetx
+      - ${HOME}/Downloads/data/biggr-static/:/static
   biggr-web-dev:
     profiles:
       - dev
@@ -33,19 +33,19 @@ services:
     networks:
       - biggr-net
     volumes:
-      - /data/biggr-genbank/:/genbank
-      - /data/biggr-metanetx/:/metanetx
-      - /data/biggr-static/:/static
+      - ${HOME}/Downloads/data/biggr-genbank/:/genbank
+      - ${HOME}/Downloads/data/biggr-metanetx/:/metanetx
+      - ${HOME}/Downloads/data/biggr-static/:/static
       - ./:/server
   biggr-db:
     container_name: biggr-postgres
     image: postgres
     restart: always
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
-      - /data/biggr-postgres:/var/lib/postgresql/data
-      - /projects/biggr/biggr_models/db/load-extensions.sh:/docker-entrypoint-initdb.d/load-extensions.sh
+      - ${HOME}/Downloads/data/biggr-postgres:/var/lib/postgresql/data
+      - ./db/load-extensions.sh:/docker-entrypoint-initdb.d/load-extensions.sh
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 1s


### PR DESCRIPTION
This PR adds 3 new POST request APIs to pankb:

interop-query/query-by-gene
interop-query/query-by-strain
interop-query/query-by-pair
These APIs are added as part of the DB interop project to unify queries for genes and strains across multiple databases.